### PR TITLE
Fix TypeError issue

### DIFF
--- a/{{cookiecutter.repo_name}}/app/views.py
+++ b/{{cookiecutter.repo_name}}/app/views.py
@@ -42,7 +42,7 @@ def index():
 
         my_prediction = estimator.predict(flower_instance)
         # Return only the Predicted iris species
-        predicted_iris = target_names[my_prediction]
+        predicted_iris = target_names[int(my_prediction)]
 
     return render_template('index.html',
         form=form,


### PR DESCRIPTION
Without casting my_prediction as an integer it throws an error.

TypeError: only integer scalar arrays can be converted to a scalar index